### PR TITLE
build(deps): bump @jimengio/fa-icons 0.1.11 -> 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react": "^16.8.3"
   },
   "devDependencies": {
-    "@jimengio/fa-icons": "^0.1.11",
+    "@jimengio/fa-icons": "^0.2.0",
     "@jimengio/shared-utils": "^0.1.3",
     "@types/node": "^11.11.6",
     "@types/react": "16.8.4",

--- a/src/components/colored-tabs/index.tsx
+++ b/src/components/colored-tabs/index.tsx
@@ -2,8 +2,7 @@ import React, { FC, useRef, MutableRefObject, useState } from "react";
 import { css, cx } from "emotion";
 import { column, row } from "@jimengio/shared-utils";
 import ReactResizeDetector from "react-resize-detector";
-import FaIcons, { IconName } from "@jimengio/fa-icons";
-import FaIcon from "@jimengio/fa-icons";
+import FaIcon, { EFaIcon } from "@jimengio/fa-icons";
 
 export interface IColoredTab {
   key?: string;
@@ -85,8 +84,8 @@ let ColoredTabs: FC<{
       </div>
       <ReactResizeDetector handleWidth onResize={onResize} />
 
-      {showLeft ? <FaIcon className={styleLeft} name={IconName.AngleLeft} onClick={onScrollLeft} /> : null}
-      {showRight ? <FaIcon className={cx(styleLeft, styleRight)} name={IconName.AngleRight} onClick={onScrollRight} /> : null}
+      {showLeft ? <FaIcon className={styleLeft} name={EFaIcon.AngleLeft} onClick={onScrollLeft} /> : null}
+      {showRight ? <FaIcon className={cx(styleLeft, styleRight)} name={EFaIcon.AngleRight} onClick={onScrollRight} /> : null}
     </div>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
 
-"@jimengio/fa-icons@^0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@jimengio/fa-icons/-/fa-icons-0.1.11.tgz#f071b7d88a9b1f189943886be9396f6400dc243e"
-  integrity sha512-jcBtzPD34VTosq1CZWAZCy9vMvZvtBlUI4HwHQ7bVnj4asJcDg1sOdn6WhrKHNNmPj3HI3RYeeS950tkc7Uwug==
+"@jimengio/fa-icons@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@jimengio/fa-icons/-/fa-icons-0.2.0.tgz#50cfe599ee4c9ab70e780be4ddc6dc78d8bd33a8"
+  integrity sha512-QpSuslOYU+cHgWNlwtQCRxHQVsm4cyzxbjeItf9NH0tW85RveNs1mJvkCD9CndehOXn04eoqxKA+Mwhju0UDaQ==
 
 "@jimengio/shared-utils@^0.1.3":
   version "0.1.3"


### PR DESCRIPTION

`@jimengio/fa-icons` 0.1.11 与 0.2.0 互不兼容（IconName -> EFaIcon）

preview: [0.1.7-a1](https://www.npmjs.com/package/@jimengio/jasmin-ui/v/0.1.7-a1)